### PR TITLE
Change the old 'die' command to be '!die'

### DIFF
--- a/scripts/ping.coffee
+++ b/scripts/ping.coffee
@@ -18,7 +18,7 @@ module.exports = (robot) ->
   robot.respond /TIME$/i, (msg) ->
     msg.send "Server time is: #{new Date()}"
 
-  robot.respond /DIE$/i, (msg) ->
+  robot.respond /!DIE$/i, (msg) ->
     msg.send "Goodbye, cruel world."
     process.exit 0
 


### PR DESCRIPTION
This is to avoid conflicts with the new 'die' alias for 'kill', and to
ensure that people killing the bot process are doing so deliberately.
